### PR TITLE
Use PSR7 request object and matomo device detector instead of filebeat-logger-php for Laravel.

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1]
+        php-version: [8.2, 8.3]
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "cego/filebeat-logger": "dev-lejo/allow-http-context-to-be-disabled",
+        "cego/filebeat-logger": "^2.0.5",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0",
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,13 @@
         }
     ],
     "require": {
-        "php": "8.x.x",
-        "cego/filebeat-logger": "^2.0.4",
+        "php": "^8.2",
+        "cego/filebeat-logger": "dev-lejo/allow-http-context-to-be-disabled",
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "illuminate/http": "^1.1",
+        "matomo/device-detector": "^6.2"
     },
     "require-dev": {
         "cego/php-cs-fixer": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
         "illuminate/contracts": "^7.0|^8.0|^9.0|^10.0",
         "ext-json": "*",
-        "illuminate/http": "^1.1",
+        "illuminate/http": "^7.0|^8.0|^9.0|^10.0",
         "matomo/device-detector": "^6.2"
     },
     "require-dev": {

--- a/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
+++ b/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
@@ -21,12 +21,13 @@ class FilebeatLoggingServiceProvider extends ServiceProvider
     public function register(): void
     {
         $config = [
-            'driver'   => 'custom',
-            'channel'  => 'filebeat',
-            'extras'   => json_decode(env('FILEBEAT_LOGGER_EXTRAS', '{}'), $assoc = true, $depth = 512, JSON_THROW_ON_ERROR),
-            'stream'   => env('FILEBEAT_LOGGER_STREAM', 'php://stdout'),
-            'rotating' => env('FILEBEAT_LOGGER_ROTATING', false),
-            'via'      => FilebeatLoggerFactory::class,
+            'driver'               => 'custom',
+            'channel'              => 'filebeat',
+            'extras'               => json_decode(env('FILEBEAT_LOGGER_EXTRAS', '{}'), associative: true, flags: JSON_THROW_ON_ERROR),
+            'stream'               => env('FILEBEAT_LOGGER_STREAM', 'php://stdout'),
+            'rotating'             => env('FILEBEAT_LOGGER_ROTATING', false),
+            'httpContextProcessor' => new RequestProcessor(),
+            'via'                  => FilebeatLoggerFactory::class,
         ];
 
         if($this->isOctane()) {

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -9,14 +9,16 @@ use DeviceDetector\DeviceDetector;
 use DeviceDetector\Cache\LaravelCache;
 use Monolog\Processor\ProcessorInterface;
 
-class RequestProcessor implements ProcessorInterface
+class FilebeatHttpContextProcessor implements ProcessorInterface
 {
     public function __invoke(LogRecord $record): LogRecord
     {
         // Get the PSR7 request from the laravel container
+        dd("wat");
         /** @var ?Request $request */
         $request = app('request'); // TODO test if we need to check if it is bound first.
 
+        dd($request);
         if($request === null) {
             return $record;
         }
@@ -32,7 +34,7 @@ class RequestProcessor implements ProcessorInterface
         return $record;
     }
 
-    public static function clientExtras(Request $request): array
+    private static function clientExtras(Request $request): array
     {
         return [
             'ip'      => $request->header('CF-Connecting-IP') ?? $request->getClientIp(),
@@ -43,7 +45,7 @@ class RequestProcessor implements ProcessorInterface
         ];
     }
 
-    public static function httpExtras(Request $request): array
+    private static function httpExtras(Request $request): array
     {
         return [
             'request' => [
@@ -53,7 +55,7 @@ class RequestProcessor implements ProcessorInterface
         ];
     }
 
-    public static function urlExtras(Request $request): array
+    private static function urlExtras(Request $request): array
     {
         return [
             'path'    => $request->path(),

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Cego\FilebeatLogging;
+
+use Monolog\LogRecord;
+use Illuminate\Http\Request;
+use DeviceDetector\ClientHints;
+use DeviceDetector\DeviceDetector;
+use DeviceDetector\Cache\LaravelCache;
+use Monolog\Processor\ProcessorInterface;
+
+class RequestProcessor implements ProcessorInterface
+{
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        // Get the PSR7 request from the laravel container
+        /** @var ?Request $request */
+        $request = app('request'); // TODO test if we need to check if it is bound first.
+
+        if($request === null) {
+            return $record;
+        }
+
+        $record->extra = array_merge(
+            $record->extra,
+            self::httpExtras($request),
+            self::urlExtras($request),
+            self::userAgentExtras($request),
+            self::clientExtras($request)
+        );
+
+        return $record;
+    }
+
+    public static function clientExtras(Request $request): array
+    {
+        return [
+            'ip'      => $request->header('CF-Connecting-IP') ?? $request->getClientIp(),
+            'address' => $request->header('X-Forwarded-For'),
+            'geo'     => [
+                'country_iso_code' => $request->header('CF-IPCountry'),
+            ],
+        ];
+    }
+
+    public static function httpExtras(Request $request): array
+    {
+        return [
+            'request' => [
+                'id'     => $request->header('CF-RAY'),
+                'method' => $request->getMethod(),
+            ],
+        ];
+    }
+
+    public static function urlExtras(Request $request): array
+    {
+        return [
+            'path'    => $request->path(),
+            'method'  => $request->getMethod(),
+            'referer' => $request->header('referer'),
+            'domain'  => $request->getHost(),
+        ];
+    }
+
+    private static function userAgentExtras(Request $request): array
+    {
+        $userAgent = $request->header('User-Agent');
+
+        if($userAgent === null) {
+            return [];
+        }
+
+        $headers = $request->headers->all();
+        // Cast all headers to string as that is the expected input to client hints factory method.
+        $headers = array_map(function ($header) {
+            return implode(';', $header);
+        }, $headers);
+
+        $clientHints = ClientHints::factory($headers);
+
+        $deviceDetector = new DeviceDetector($userAgent, $clientHints);
+        $deviceDetector->setCache(new LaravelCache());
+
+        $deviceDetector->parse();
+
+        return [
+            'original' => $userAgent,
+            'browser'  => [
+                'name'    => $deviceDetector->getClient('name'),
+                'version' => $deviceDetector->getClient('version'),
+            ],
+            'os' => [
+                'name'    => $deviceDetector->getOs('name'),
+                'version' => $deviceDetector->getOs('version'),
+            ],
+            'device' => [
+                'brand' => $deviceDetector->getBrandName(),
+                'model' => $deviceDetector->getModel(),
+            ],
+        ];
+    }
+}

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -13,9 +13,12 @@ class RequestProcessor implements ProcessorInterface
 {
     public function __invoke(LogRecord $record): LogRecord
     {
-        // Get the PSR7 request from the laravel container
+        if(app()->runningInConsole()) {
+            return $record;
+        }
+
         /** @var ?Request $request */
-        $request = app('request'); // TODO test if we need to check if it is bound first.
+        $request = app('request');
 
         if($request === null) {
             return $record;

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -9,26 +9,24 @@ use DeviceDetector\DeviceDetector;
 use DeviceDetector\Cache\LaravelCache;
 use Monolog\Processor\ProcessorInterface;
 
-class FilebeatHttpContextProcessor implements ProcessorInterface
+class RequestProcessor implements ProcessorInterface
 {
     public function __invoke(LogRecord $record): LogRecord
     {
         // Get the PSR7 request from the laravel container
-        dd("wat");
         /** @var ?Request $request */
         $request = app('request'); // TODO test if we need to check if it is bound first.
 
-        dd($request);
         if($request === null) {
             return $record;
         }
 
         $record->extra = array_merge(
             $record->extra,
-            self::httpExtras($request),
-            self::urlExtras($request),
-            self::userAgentExtras($request),
-            self::clientExtras($request)
+            ['http'       => self::httpExtras($request)],
+            ['url'        => self::urlExtras($request)],
+            ['user_agent' => self::userAgentExtras($request)],
+            ['client'     => self::clientExtras($request)]
         );
 
         return $record;

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -98,8 +98,11 @@ class RequestProcessor implements ProcessorInterface
                 'version' => $deviceDetector->getOs('version'),
             ],
             'device' => [
-                'brand' => $deviceDetector->getBrandName(),
-                'model' => $deviceDetector->getModel(),
+                'isMobile'  => $deviceDetector->isMobile(),
+                'isDesktop' => $deviceDetector->isDesktop(),
+                'isBot'     => $deviceDetector->isBot(),
+                'brand'     => $deviceDetector->getBrandName(),
+                'model'     => $deviceDetector->getModel(),
             ],
         ];
     }


### PR DESCRIPTION
PSR7 request object works with long running laravel, i.e. octane. Device detector adds new capabilities of reading device data from client hints, to be able to detect Android >10, Windows >10 and more.

https://github.com/cego/filebeat-logger-php/pull/49 should be merged first.