### PR TITLE
Removed octane specific logging

### DIFF
--- a/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
+++ b/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
@@ -4,7 +4,6 @@ namespace Cego\FilebeatLogging;
 
 use JsonException;
 use Cego\FilebeatLoggerFactory;
-use Monolog\Handler\ProcessHandler;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Debug\ExceptionHandler;

--- a/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
+++ b/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
@@ -30,19 +30,9 @@ class FilebeatLoggingServiceProvider extends ServiceProvider
             'via'                  => FilebeatLoggerFactory::class,
         ];
 
-        if($this->isOctane()) {
-            $config['handler'] = new ProcessHandler('cat >> /proc/1/fd/1');
-        }
-
         Config::set('logging.channels.filebeat', $config);
 
         /* @phpstan-ignore-next-line */
         $this->app->bind(ExceptionHandler::class, LoggerExceptionHandler::class);
-    }
-
-    /** Detect if application is running octane */
-    protected function isOctane(): bool
-    {
-        return isset($_SERVER['LARAVEL_OCTANE']) && ((int)$_SERVER['LARAVEL_OCTANE'] === 1);
     }
 }


### PR DESCRIPTION
This hack is no longer needed, as Octane can handle the stdout throughput now. https://github.com/laravel/octane/pull/902