### PR TITLE
Use apcu instead of laravel cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "illuminate/contracts": "^11.0",
         "ext-json": "*",
         "illuminate/http": "^11.0",
-        "matomo/device-detector": "^6.2"
+        "matomo/device-detector": "^6.2",
+        "ext-apcu": "*"
     },
     "require-dev": {
         "cego/php-cs-fixer": "2.0.0"

--- a/src/FilebeatLogging/ApcuCache.php
+++ b/src/FilebeatLogging/ApcuCache.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cego\FilebeatLogging;
+
+use DeviceDetector\Cache\CacheInterface;
+
+class ApcuCache implements CacheInterface
+{
+    public function fetch(string $id)
+    {
+        return apcu_fetch($id);
+    }
+
+    public function contains(string $id): bool
+    {
+        return apcu_exists($id);
+    }
+
+    public function save(string $id, $data, int $lifeTime = 0): bool
+    {
+        return apcu_store($id, $data, $lifeTime);
+    }
+
+    public function delete(string $id): bool
+    {
+        return apcu_delete($id);
+    }
+
+    public function flushAll(): bool
+    {
+        return apcu_clear_cache();
+    }
+}

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -83,7 +83,7 @@ class RequestProcessor implements ProcessorInterface
         $clientHints = ClientHints::factory($headers);
 
         $deviceDetector = new DeviceDetector($userAgent, $clientHints);
-        $deviceDetector->setCache(new LaravelCache());
+        $deviceDetector->setCache(new ApcuCache());
 
         $deviceDetector->parse();
 

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -6,7 +6,6 @@ use Monolog\LogRecord;
 use Illuminate\Http\Request;
 use DeviceDetector\ClientHints;
 use DeviceDetector\DeviceDetector;
-use DeviceDetector\Cache\LaravelCache;
 use Monolog\Processor\ProcessorInterface;
 
 class RequestProcessor implements ProcessorInterface


### PR DESCRIPTION
As laravel cache is now default database driver in Laravel 11 it is undesired to use it as cache driver for device detector