### PR TITLE
Add Laravel v13 support to illuminate package constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
     "require": {
         "php": "^8.3",
         "cego/filebeat-logger": "^2.0.6",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/http": "^11.0|^12.0|^13.0",
         "ext-json": "*",
         "matomo/device-detector": "^6.2",
         "ext-apcu": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d99be8d806c67a57135e10a7c2019c90",
+    "content-hash": "7ced15ef3549b49c15b7dd515e00c7a7",
     "packages": [
         {
             "name": "brick/math",
@@ -9627,5 +9627,5 @@
         "ext-apcu": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Adds `^13.0` to all `illuminate/*` version constraints and updates the lock file.