### PR TITLE
Cache DeviceDetector parse results per UA + client hints

### DIFF
--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -10,6 +10,37 @@ use Monolog\Processor\ProcessorInterface;
 
 class RequestProcessor implements ProcessorInterface
 {
+    /**
+     * Headers inspected by DeviceDetector\ClientHints::factory(). Included in
+     * the parse-result cache key so responses with different client hints do
+     * not collide on the same User-Agent string.
+     */
+    private const CLIENT_HINT_HEADERS = [
+        'sec-ch-ua',
+        'sec-ch-ua-mobile',
+        'sec-ch-ua-platform',
+        'sec-ch-ua-platform-version',
+        'sec-ch-ua-full-version-list',
+        'sec-ch-ua-full-version',
+        'sec-ch-ua-model',
+        'sec-ch-ua-arch',
+        'sec-ch-ua-bitness',
+        'sec-ch-ua-wow64',
+    ];
+
+    private const CACHE_MAX_ENTRIES = 1024;
+
+    /**
+     * Per-worker memoization of userAgentExtras() results keyed on
+     * User-Agent + client-hint headers. A single DeviceDetector::parse()
+     * call costs several milliseconds even with PreloadCache warm, and
+     * this processor runs once per log record — so a request emitting
+     * N log lines pays N parses for the same UA without this cache.
+     *
+     * @var array<string, array<array-key, mixed>>
+     */
+    private static array $userAgentCache = [];
+
     public function __invoke(LogRecord $record): LogRecord
     {
         if (app()->runningInConsole()) {
@@ -112,13 +143,19 @@ class RequestProcessor implements ProcessorInterface
             return implode(';', $header);
         }, $headers);
 
+        $cacheKey = self::cacheKey($userAgent, $headers);
+
+        if (isset(self::$userAgentCache[$cacheKey])) {
+            return self::$userAgentCache[$cacheKey];
+        }
+
         $clientHints = ClientHints::factory($headers);
 
         $deviceDetector = new DeviceDetector($userAgent, $clientHints);
         $deviceDetector->setCache(new PreloadCache());
         $deviceDetector->parse();
 
-        return [
+        $result = [
             'original' => $userAgent,
             'browser'  => [
                 'name'    => $deviceDetector->getClient('name'),
@@ -137,5 +174,31 @@ class RequestProcessor implements ProcessorInterface
                 'model'     => $deviceDetector->getModel(),
             ],
         ];
+
+        if (count(self::$userAgentCache) >= self::CACHE_MAX_ENTRIES) {
+            array_shift(self::$userAgentCache);
+        }
+
+        self::$userAgentCache[$cacheKey] = $result;
+
+        return $result;
+    }
+
+    /**
+     * @param string $userAgent
+     * @param array<string, string> $headers
+     *
+     * @return string
+     */
+    private static function cacheKey(string $userAgent, array $headers): string
+    {
+        $hintBits = '';
+        foreach (self::CLIENT_HINT_HEADERS as $name) {
+            if (isset($headers[$name])) {
+                $hintBits .= $name . '=' . $headers[$name] . "\n";
+            }
+        }
+
+        return $userAgent . "\0" . $hintBits;
     }
 }

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -193,6 +193,7 @@ class RequestProcessor implements ProcessorInterface
     private static function cacheKey(string $userAgent, array $headers): string
     {
         $hintBits = '';
+
         foreach (self::CLIENT_HINT_HEADERS as $name) {
             if (isset($headers[$name])) {
                 $hintBits .= $name . '=' . $headers[$name] . "\n";

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -31,11 +31,14 @@ class RequestProcessor implements ProcessorInterface
     private const CACHE_MAX_ENTRIES = 1024;
 
     /**
-     * Per-worker memoization of userAgentExtras() results keyed on
+     * Per-worker LRU memoization of userAgentExtras() results keyed on
      * User-Agent + client-hint headers. A single DeviceDetector::parse()
      * call costs several milliseconds even with PreloadCache warm, and
      * this processor runs once per log record — so a request emitting
      * N log lines pays N parses for the same UA without this cache.
+     *
+     * Ordering relies on PHP arrays preserving insertion order: hits
+     * re-insert at the tail, so array_shift() evicts the least-recently-used.
      *
      * @var array<string, array<array-key, mixed>>
      */
@@ -146,7 +149,12 @@ class RequestProcessor implements ProcessorInterface
         $cacheKey = self::cacheKey($userAgent, $headers);
 
         if (isset(self::$userAgentCache[$cacheKey])) {
-            return self::$userAgentCache[$cacheKey];
+            // Move to tail so it counts as most-recently-used.
+            $cached = self::$userAgentCache[$cacheKey];
+            unset(self::$userAgentCache[$cacheKey]);
+            self::$userAgentCache[$cacheKey] = $cached;
+
+            return $cached;
         }
 
         $clientHints = ClientHints::factory($headers);
@@ -176,6 +184,7 @@ class RequestProcessor implements ProcessorInterface
         ];
 
         if (count(self::$userAgentCache) >= self::CACHE_MAX_ENTRIES) {
+            // Oldest entry sits at the head; hits re-insert at the tail, making this LRU eviction.
             array_shift(self::$userAgentCache);
         }
 

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -10,11 +10,6 @@ use Monolog\Processor\ProcessorInterface;
 
 class RequestProcessor implements ProcessorInterface
 {
-    /**
-     * Headers inspected by DeviceDetector\ClientHints::factory(). Included in
-     * the parse-result cache key so responses with different client hints do
-     * not collide on the same User-Agent string.
-     */
     private const CLIENT_HINT_HEADERS = [
         'sec-ch-ua',
         'sec-ch-ua-mobile',
@@ -30,18 +25,7 @@ class RequestProcessor implements ProcessorInterface
 
     private const CACHE_MAX_ENTRIES = 1024;
 
-    /**
-     * Per-worker LRU memoization of userAgentExtras() results keyed on
-     * User-Agent + client-hint headers. A single DeviceDetector::parse()
-     * call costs several milliseconds even with PreloadCache warm, and
-     * this processor runs once per log record — so a request emitting
-     * N log lines pays N parses for the same UA without this cache.
-     *
-     * Ordering relies on PHP arrays preserving insertion order: hits
-     * re-insert at the tail, so array_shift() evicts the least-recently-used.
-     *
-     * @var array<string, array<array-key, mixed>>
-     */
+    /** @var array<string, array<array-key, mixed>> */
     private static array $userAgentCache = [];
 
     public function __invoke(LogRecord $record): LogRecord

--- a/src/FilebeatLogging/RequestProcessor.php
+++ b/src/FilebeatLogging/RequestProcessor.php
@@ -10,19 +10,6 @@ use Monolog\Processor\ProcessorInterface;
 
 class RequestProcessor implements ProcessorInterface
 {
-    private const CLIENT_HINT_HEADERS = [
-        'sec-ch-ua',
-        'sec-ch-ua-mobile',
-        'sec-ch-ua-platform',
-        'sec-ch-ua-platform-version',
-        'sec-ch-ua-full-version-list',
-        'sec-ch-ua-full-version',
-        'sec-ch-ua-model',
-        'sec-ch-ua-arch',
-        'sec-ch-ua-bitness',
-        'sec-ch-ua-wow64',
-    ];
-
     private const CACHE_MAX_ENTRIES = 1024;
 
     /** @var array<string, array<array-key, mixed>> */
@@ -130,7 +117,8 @@ class RequestProcessor implements ProcessorInterface
             return implode(';', $header);
         }, $headers);
 
-        $cacheKey = self::cacheKey($userAgent, $headers);
+        $clientHints = ClientHints::factory($headers);
+        $cacheKey = $userAgent . "\0" . serialize($clientHints);
 
         if (isset(self::$userAgentCache[$cacheKey])) {
             // Move to tail so it counts as most-recently-used.
@@ -140,8 +128,6 @@ class RequestProcessor implements ProcessorInterface
 
             return $cached;
         }
-
-        $clientHints = ClientHints::factory($headers);
 
         $deviceDetector = new DeviceDetector($userAgent, $clientHints);
         $deviceDetector->setCache(new PreloadCache());
@@ -175,24 +161,5 @@ class RequestProcessor implements ProcessorInterface
         self::$userAgentCache[$cacheKey] = $result;
 
         return $result;
-    }
-
-    /**
-     * @param string $userAgent
-     * @param array<string, string> $headers
-     *
-     * @return string
-     */
-    private static function cacheKey(string $userAgent, array $headers): string
-    {
-        $hintBits = '';
-
-        foreach (self::CLIENT_HINT_HEADERS as $name) {
-            if (isset($headers[$name])) {
-                $hintBits .= $name . '=' . $headers[$name] . "\n";
-            }
-        }
-
-        return $userAgent . "\0" . $hintBits;
     }
 }


### PR DESCRIPTION
Memoize `userAgentExtras()` results keyed on User-Agent + the client-hint headers `ClientHints::factory()` inspects, bounded to 1024 entries per worker.

The log processor runs once per log record and each invocation creates a fresh `DeviceDetector` and calls `->parse()`. `PreloadCache` warms DeviceDetector's internal rule data but does not memoize parse results, so a request emitting N log lines pays N parses for the same UA. On a webhook with a stable User-Agent (e.g. `Go-http-client/2.0`), APM shows this costing ~95 ms per request across ~12 log lines. With the cache, the second-and-onwards calls are array lookups.