### PR TITLE
Forward Log::withContext / Log::shareContext to FrankenPHP request-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,25 @@
 #### Install via composer
 ```
 composer require cego/filebeat-logger-laravel
+```
+
+## FrankenPHP request-log context forwarding
+
+When the app runs under the `cego/frankenphp-image` runtime, this package
+transparently forwards context attached via Laravel's `Log` facade into the
+FrankenPHP `request-logs` Caddy middleware, so fields like `user.id` appear
+on the final access-log line in addition to per-record app logs.
+
+Hooks that forward:
+
+- `Log::withContext([...])` — forwarded to `\Cego\RequestLogs\context()`
+  before delegating to the default channel's logger.
+- `Log::shareContext([...])` — forwarded before applying to all channels.
+
+Not forwarded: `Log::channel('x')->withContext([...])`. Per-channel context
+scoping does not map to a cross-cutting request log entry — use
+`Log::withContext()` or `Log::shareContext()` for fields that should land
+on the access log.
+
+Outside FrankenPHP (php-fpm, CLI, queue workers), the forward is a no-op
+because `\Cego\RequestLogs\context()` is not defined.

--- a/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
+++ b/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
@@ -55,5 +55,10 @@ class FilebeatLoggingServiceProvider extends ServiceProvider
         Config::set('logging.channels.deprecations', $deprecationsConfig);
 
         $this->app->bind(ExceptionHandler::class, LoggerExceptionHandler::class);
+
+        // Rebind the log manager so Log::withContext() / Log::shareContext()
+        // also forward into the FrankenPHP request-logs extension. When the
+        // extension is absent this is a pure passthrough.
+        $this->app->singleton('log', fn ($app) => new ForwardingLogManager($app));
     }
 }

--- a/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
+++ b/src/FilebeatLogging/FilebeatLoggingServiceProvider.php
@@ -4,6 +4,7 @@ namespace Cego\FilebeatLogging;
 
 use JsonException;
 use Cego\FilebeatLoggerFactory;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
@@ -59,6 +60,11 @@ class FilebeatLoggingServiceProvider extends ServiceProvider
         // Rebind the log manager so Log::withContext() / Log::shareContext()
         // also forward into the FrankenPHP request-logs extension. When the
         // extension is absent this is a pure passthrough.
+        //
+        // singleton() drops any previously cached container instance, but the
+        // Log facade has its own resolved-instance cache that needs clearing
+        // so the facade re-resolves through our rebound factory.
         $this->app->singleton('log', fn ($app) => new ForwardingLogManager($app));
+        Log::clearResolvedInstance('log');
     }
 }

--- a/src/FilebeatLogging/ForwardingLogManager.php
+++ b/src/FilebeatLogging/ForwardingLogManager.php
@@ -51,8 +51,27 @@ class ForwardingLogManager extends LogManager
      */
     private static function forwardToRequestLogs(array $context): void
     {
-        if (function_exists('\\Cego\\RequestLogs\\context')) {
-            \Cego\RequestLogs\context($context);
+        if (! function_exists('\\Cego\\RequestLogs\\context')) {
+            return;
         }
+
+        // The extension converts the array to Go primitives via
+        // frankenphp.GoMap, which silently drops the entire call when it
+        // encounters a PHP object (UuidInterface, Carbon, etc.). Round-trip
+        // through JSON to flatten objects to their scalar representation so
+        // the payload survives. The original $context is untouched, so
+        // parent::shareContext() / standard Monolog handlers still see the
+        // objects and serialize them their own way.
+        $encoded = json_encode($context);
+        if ($encoded === false) {
+            return;
+        }
+
+        $flat = json_decode($encoded, associative: true);
+        if (! is_array($flat)) {
+            return;
+        }
+
+        \Cego\RequestLogs\context($flat);
     }
 }

--- a/src/FilebeatLogging/ForwardingLogManager.php
+++ b/src/FilebeatLogging/ForwardingLogManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Cego\FilebeatLogging;
+
+use Illuminate\Log\LogManager;
+
+/**
+ * LogManager decorator that forwards context into the FrankenPHP
+ * request-logs extension (\Cego\RequestLogs\context) so fields attached
+ * via Log::withContext() / Log::shareContext() also appear on the final
+ * access log line emitted by the Go middleware.
+ *
+ * When the extension is not loaded (e.g. php-fpm, CLI), the forward is
+ * a no-op and standard Laravel logging behavior is unchanged.
+ */
+class ForwardingLogManager extends LogManager
+{
+    /**
+     * @param  array<array-key, mixed>  $context
+     *
+     * @return $this
+     */
+    public function shareContext(array $context)
+    {
+        self::forwardToRequestLogs($context);
+
+        return parent::shareContext($context);
+    }
+
+    /**
+     * Catches Log::withContext(...) (which reaches the manager via __call
+     * and is forwarded to the default driver). Direct channel calls like
+     * Log::channel('x')->withContext(...) bypass this and are not forwarded.
+     *
+     * @param  string  $method
+     * @param  array<array-key, mixed>  $parameters
+     *
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if ($method === 'withContext' && isset($parameters[0]) && is_array($parameters[0])) {
+            self::forwardToRequestLogs($parameters[0]);
+        }
+
+        return parent::__call($method, $parameters);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $context
+     */
+    private static function forwardToRequestLogs(array $context): void
+    {
+        if (function_exists('\\Cego\\RequestLogs\\context')) {
+            \Cego\RequestLogs\context($context);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ForwardingLogManager` that extends `Illuminate\Log\LogManager` and forwards context attached via `Log::withContext()` and `Log::shareContext()` into the FrankenPHP `request-logs` extension (`\Cego\RequestLogs\context()`).
- `FilebeatLoggingServiceProvider::register()` rebinds the `log` singleton to the forwarding manager.
- When the FrankenPHP extension is absent (php-fpm, CLI, queue workers) the forward is a no-op — standard Laravel logging behavior is preserved.

## Context

Companion to cego/frankenphp-image!264, which adds a Go-side per-request context store and the PHP function `\Cego\RequestLogs\context()`. This package is the idiomatic Laravel bridge: application code calls `Log::withContext(['user' => ['id' => $id]])` from middleware, and the fields appear on both the Monolog app-log records AND the final access-log line emitted by the Caddy `request-logs` middleware.

## Not forwarded

`Log::channel('x')->withContext([...])` — per-channel scoping does not map cleanly to a cross-cutting request log entry. Documented in the README section.